### PR TITLE
Add sort-packages to prevent silly merge conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
   },
   "config": {
     "optimize-autoloader": true,
+    "sort-packages": true,
     "platform": {
       "php": "7.0"
     }


### PR DESCRIPTION
As we keep a fork maintained of this, and want to pull in your improvements as well as keep our own specific ones, this makes it easier as there won't be silly merge conflicts based on which line there are packages.

You'll have to run a `composer update` or `composer install` before the packages are sorted.