### PR TITLE
Fix install blocking package version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "nystudio107/craft-imageoptimize": "^1.3.2",
     "nystudio107/craft-minify": "^1.2.5",
     "nystudio107/craft-routemap": "^1.0.0",
-    "nystudio107/craft-seomatic": "^1.0.0",
+    "nystudio107/craft-seomatic": "^3.0.0",
     "nystudio107/craft-typogrify": "^1.1.1",
     "ostark/craft-async-queue": "^1.3.0"
   },


### PR DESCRIPTION
At some point, seomatic went to version`3.x.x` while still being listed in `composer.json` as `^1.0.0`.

This caused the following error on running a clean `rm -fR .vendor && composer install`.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package nystudio107/craft-seomatic ^1.0.0 exists as nystudio107/craft-seomatic[3.0.0, 3.0.0-beta.1, 3.0.0-beta.10, 3.0.0-beta.11, 3.0.0-beta.12, 3.0.0-beta.13, 3.0.0-beta.14, 3.0.0-beta.15, 3.0.0-beta.16, 3.0.0-beta.17, 3.0.0-beta.18, 3.0.0-beta.19, 3.0.0-beta.2, 3.0.0-beta.20, 3.0.0-beta.21, 3.0.0-beta.22, 3.0.0-beta.23, 3.0.0-beta.24, 3.0.0-beta.3, 3.0.0-beta.4, 3.0.0-beta.5, 3.0.0-beta.6, 3.0.0-beta.7, 3.0.0-beta.8, 3.0.0-beta.9, 3.0.1, 3.0.10, 3.0.11, 3.0.12, 3.0.13, 3.0.14, 3.0.15, 3.0.16, 3.0.17, 3.0.18, 3.0.2, 3.0.20, 3.0.22, 3.0.23, 3.0.24, 3.0.25, 3.0.3, 3.0.4, 3.0.5, 3.0.6, 3.0.7, 3.0.8, 3.0.9, 3.1.0, 3.1.1, 3.1.10, 3.1.11, 3.1.12, 3.1.13, 3.1.13.1, 3.1.14, 3.1.16, 3.1.17, 3.1.18, 3.1.18.1, 3.1.19, 3.1.2, 3.1.20, 3.1.21, 3.1.22, 3.1.23, 3.1.24, 3.1.25, 3.1.26, 3.1.27, 3.1.28, 3.1.29, 3.1.3, 3.1.30, 3.1.31, 3.1.32, 3.1.33, 3.1.4, 3.1.5, 3.1.6, 3.1.7, 3.1.8, 3.1.9, dev-develop, v3.x-dev] but these are rejected by your constraint.
```