### PR TITLE
Add correct `at-rule-no-unknown` config

### DIFF
--- a/buildchain/.stylelintrc.json
+++ b/buildchain/.stylelintrc.json
@@ -5,11 +5,11 @@
     "stylelint-config-recommended-vue"
   ],
   "rules": {
-    "at-rule-no-unknown": [ true, {
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": [ true, {
       "ignoreAtRules": [
-        "apply",
-        "extends",
         "screen",
+        "extends",
         "responsive",
         "tailwind"
       ]


### PR DESCRIPTION
The current ruleset when linting will still give an issue on `@responsive`.

The correct way according to the stylelint [docs](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-rule-no-unknown/README.md) is by disabling the standard `at-rule-no-unknown` and replace it by the SCSS version.