### PR TITLE
check if node_modlules is empty

### DIFF
--- a/docker-config/node-dev-vite/npm_install.sh
+++ b/docker-config/node-dev-vite/npm_install.sh
@@ -11,6 +11,6 @@
 # @license   MIT
 
 cd /var/www/project/buildchain
-if [ ! -f "package-lock.json" ] || [ ! -d "node_modules" ]; then
+if [ ! -f "package-lock.json" ] || [ ! -n "$(ls -A node_modules 2>/dev/null)" ]; then
     npm install
 fi


### PR DESCRIPTION
Check if node_modules is empty or does not exist instead of just does not exist.

### Description

Checking if the directory is empty allows the container to know it needs to run `npm install` when there is already a `package-lock.json` file

### Related issues

issue #82 
